### PR TITLE
Add sheet identifier to Google Sheets URL

### DIFF
--- a/src/googleSheets.ts
+++ b/src/googleSheets.ts
@@ -95,7 +95,37 @@ export async function writeCsvToGoogleSheet(rows: CsvRow[], url: string): Promis
     throw new Error(`Invalid Google Sheets URL: ${url}`);
   }
   const spreadsheetId = match[1];
-  const range = 'A1:ZZZ';
+
+  let range = 'A1:ZZZ';
+  const gid = Number(new URL(url).searchParams.get('gid'));
+  if (gid) {
+    const spreadsheet = await sheets.spreadsheets.get({ spreadsheetId, auth });
+    const sheetName = spreadsheet.data.sheets?.find((sheet) => sheet.properties?.sheetId === gid)
+      ?.properties?.title;
+    if (!sheetName) {
+      throw new Error(`Sheet not found for gid: ${gid}`);
+    }
+    range = `${sheetName}!${range}`;
+  } else {
+    // Create a new sheet if no gid is provided
+    const newSheetTitle = `Sheet${Date.now()}`;
+    await sheets.spreadsheets.batchUpdate({
+      spreadsheetId,
+      auth,
+      requestBody: {
+        requests: [
+          {
+            addSheet: {
+              properties: {
+                title: newSheetTitle,
+              },
+            },
+          },
+        ],
+      },
+    });
+    range = `${newSheetTitle}!${range}`;
+  }
 
   // Extract headers from the first row
   const headers = Object.keys(rows[0]);


### PR DESCRIPTION
This update makes it easier to manage test cases in Google Sheets. You can now specify which sheet to use by adding the gid from the sheet’s URL to your YAML configuration. No more being stuck with the first sheet!

If you don’t provide a gid, a brand-new sheet will be created automatically, so you won’t accidentally overwrite any existing test case answers. Want to overwrite something? Just include the gid of the sheet you want to update.

This change keeps things flexible and helps avoid headaches when working with multiple sheets in a single document.